### PR TITLE
Remove Offscreen Objects

### DIFF
--- a/das-teroids/scenes/main_level.tscn
+++ b/das-teroids/scenes/main_level.tscn
@@ -9,6 +9,7 @@
 font_size = 144
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_qmak7"]
+size = Vector2(1154, 649)
 
 [node name="MainLevel" type="Node2D"]
 script = ExtResource("4_qmak7")
@@ -32,6 +33,7 @@ vertical_alignment = 1
 [node name="ValidSpace" type="Area2D" parent="."]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ValidSpace"]
+position = Vector2(576, 326.5)
 shape = SubResource("RectangleShape2D_qmak7")
 debug_color = Color(0, 0.6, 0.69803923, 0.043137256)
 

--- a/das-teroids/scenes/main_level.tscn
+++ b/das-teroids/scenes/main_level.tscn
@@ -1,12 +1,14 @@
-[gd_scene load_steps=6 format=3 uid="uid://dhm28ne3u5nwa"]
+[gd_scene load_steps=7 format=3 uid="uid://dhm28ne3u5nwa"]
 
-[ext_resource type="PackedScene" uid="uid://dtupna0ajt487" path="res://scenes/asteroid_spawner.tscn" id="2_6we3w"]
+[ext_resource type="PackedScene" uid="uid://cjsgle643hohi" path="res://scenes/asteroid_spawner.tscn" id="2_6we3w"]
 [ext_resource type="PackedScene" uid="uid://drxv3m3tji3j3" path="res://scenes/player.tscn" id="2_ufxs0"]
 [ext_resource type="PackedScene" uid="uid://bfjxjanc6tx24" path="res://scenes/score_keeper.tscn" id="3_6we3w"]
 [ext_resource type="Script" uid="uid://bag8il0k4pc4d" path="res://scripts/main_level.gd" id="4_qmak7"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_qmak7"]
 font_size = 144
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_qmak7"]
 
 [node name="MainLevel" type="Node2D"]
 script = ExtResource("4_qmak7")
@@ -27,4 +29,11 @@ label_settings = SubResource("LabelSettings_qmak7")
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="ValidSpace" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="ValidSpace"]
+shape = SubResource("RectangleShape2D_qmak7")
+debug_color = Color(0, 0.6, 0.69803923, 0.043137256)
+
 [connection signal="dead" from="Player" to="." method="_on_player_death"]
+[connection signal="area_exited" from="ValidSpace" to="." method="_on_valid_space_area_exited"]

--- a/das-teroids/scripts/main_level.gd
+++ b/das-teroids/scripts/main_level.gd
@@ -5,12 +5,15 @@ extends Node
 @onready var asteroid_spawner: Node2D = $AsteroidSpawner
 @onready var valid_space: CollisionShape2D = $ValidSpace/CollisionShape2D
 
+
 func _ready() -> void:
 	get_viewport().connect("size_changed", _on_viewport_size_change)
+
 
 #####################
 #  Signal Handlers  #
 #####################
+
 
 # Handles player death
 func _on_player_death() -> void:
@@ -18,6 +21,7 @@ func _on_player_death() -> void:
 	score_timer.stop()
 	game_over.size = get_viewport().size
 	game_over.visible = true
+
 
 func _on_viewport_size_change() -> void:
 	print("Resizing valid space")

--- a/das-teroids/scripts/main_level.gd
+++ b/das-teroids/scripts/main_level.gd
@@ -24,7 +24,7 @@ func _on_viewport_size_change() -> void:
 	var view_rect = valid_space.get_viewport_rect()
 	valid_space.shape.size = view_rect.size
 	valid_space.position = view_rect.size / 2
-pass # Replace with function body.
+
 
 func _on_valid_space_area_exited(area: Area2D) -> void:
 	print("Deleting area: " + str(area))

--- a/das-teroids/scripts/main_level.gd
+++ b/das-teroids/scripts/main_level.gd
@@ -1,10 +1,16 @@
 extends Node
 
 @onready var score_timer: Timer = $ScoreKeeper/ScoreTimer
-
 @onready var game_over: Label = $GameOver
 @onready var asteroid_spawner: Node2D = $AsteroidSpawner
+@onready var valid_space: CollisionShape2D = $ValidSpace/CollisionShape2D
 
+func _ready() -> void:
+	get_viewport().connect("size_changed", _on_viewport_size_change)
+
+#####################
+#  Signal Handlers  #
+#####################
 
 # Handles player death
 func _on_player_death() -> void:
@@ -12,3 +18,14 @@ func _on_player_death() -> void:
 	score_timer.stop()
 	game_over.size = get_viewport().size
 	game_over.visible = true
+
+func _on_viewport_size_change() -> void:
+	print("Resizing valid space")
+	var view_rect = valid_space.get_viewport_rect()
+	valid_space.shape.size = view_rect.size
+	valid_space.position = view_rect.size / 2
+pass # Replace with function body.
+
+func _on_valid_space_area_exited(area: Area2D) -> void:
+	print("Deleting area: " + str(area))
+	area.call_deferred("queue_free")

--- a/das-teroids/scripts/projectile.gd
+++ b/das-teroids/scripts/projectile.gd
@@ -15,4 +15,5 @@ func _on_area_entered(area: Area2D) -> void:
 	print("Proj hit area...")
 	if area.has_method("hit"):
 		area.hit()
-	call_deferred("queue_free")
+		call_deferred("queue_free")
+	

--- a/das-teroids/scripts/projectile.gd
+++ b/das-teroids/scripts/projectile.gd
@@ -16,4 +16,3 @@ func _on_area_entered(area: Area2D) -> void:
 	if area.has_method("hit"):
 		area.hit()
 		call_deferred("queue_free")
-	


### PR DESCRIPTION
### Files Modified

Modify `das-teroids/scenes/main_level.tscn`
Modify `das-teroids/scripts/main_level.gd`
Modify `das-teroids/scripts/projectile.gd`

### Description

Objects that go offscreen are removed from the scene tree

### Implementation Details

1. Added `Area2D` with rectangular collision to `main_level`
2. Set up signal handlers to resize area to match screen size
3. Added signal handler to delete any area that exits this valid area
4. Updated `projectiles.gd` to only delete itself if it successfully calls `hit()` on the object it collides wtih
