### PR TITLE
fixed screen size scale

### DIFF
--- a/das-teroids/project.godot
+++ b/das-teroids/project.godot
@@ -23,6 +23,7 @@ SignalBus="*res://scripts/signal_bus.gd"
 
 window/size/viewport_width=1900
 window/size/viewport_height=890
+window/stretch/mode="canvas_items"
 
 [global_group]
 


### PR DESCRIPTION
### Files Modified

Modify `das-teroids/project.godot`

### Description

Scale game to biggest size that can fit on screen

### Implementation Ideas
1. Adjust project settings to scale game to screen size